### PR TITLE
fix(chat): center hero glow on the composer (mobile alignment)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1984,9 +1984,10 @@ body {
   max-width: 720px;
 }
 
-/* Glow ellipse — sibling of the composer inside .chat-hero. The hero
-   uses `isolation: isolate` so this glow stays trapped in its stacking
-   context and never bleeds in front of the pill or chips. */
+/* Glow ellipse — anchored to .chat-hero-composer (not the whole hero)
+   so it always centers on the composer pill regardless of viewport
+   height. The hero uses `isolation: isolate` so the glow can never
+   bleed in front of the pill or chips. */
 .chat-hero-glow {
   position: absolute;
   top: 50%;
@@ -2025,9 +2026,9 @@ body {
     font-size: 1.35rem;
   }
   .chat-hero-glow {
-    width: 95vw;
-    height: 280px;
-    filter: blur(36px);
+    width: 130vw;
+    height: 320px;
+    filter: blur(40px);
   }
   .chat-hero-suggestions {
     margin-top: 0.5rem;

--- a/src/components/chat/ChatWelcome.tsx
+++ b/src/components/chat/ChatWelcome.tsx
@@ -18,7 +18,6 @@ export default function ChatWelcome({ suggestions, onSendSuggestion, composer }:
 
     return (
         <div className="chat-hero">
-            <div className="chat-hero-glow" aria-hidden="true" />
             <FadeIn direction="up" distance={12} duration={0.5}>
                 <h1 className="chat-hero-title">{t('heroTitle')}</h1>
             </FadeIn>
@@ -41,7 +40,10 @@ export default function ChatWelcome({ suggestions, onSendSuggestion, composer }:
             </FadeIn>
 
             <FadeIn delay={0.2} direction="up" distance={16} duration={0.55}>
-                <div className="chat-hero-composer">{composer}</div>
+                <div className="chat-hero-composer">
+                    <div className="chat-hero-glow" aria-hidden="true" />
+                    {composer}
+                </div>
             </FadeIn>
 
             <div className="welcome-suggestions chat-hero-suggestions">


### PR DESCRIPTION
On narrow viewports the glow used to anchor to the .chat-hero box, so its 50/50 origin landed below the composer (between the pill and the suggestion chips) instead of right behind it.

- Move the glow element to be a child of .chat-hero-composer so its top:50%/left:50% always centers on the pill itself, regardless of how tall the hero ends up being.
- Bump the mobile glow width from 95vw to 130vw (and height 280px → 320px) so it visibly extends past the pill instead of being narrower than it.

## Summary

<!-- Brief description of what this PR does -->

## Changes

-

## Testing

- [ ] Lint passes
- [ ] Tests pass
- [ ] Tested manually

## Notes

<!-- Any additional context for reviewers -->
